### PR TITLE
Removed abandoned package symfony/debug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
         "symfony-cmf/routing": "^2.3.3 || ^3.0.0",
         "symfony/config": "^5.0.9 || ^6.0.0",
         "symfony/console": "^5.3.0 || ^6.0.0",
-        "symfony/debug": "^4.4.9",
         "symfony/error-handler": "^5.0.9 || ^6.0.0",
         "symfony/event-dispatcher": "^5.1.0 || ^6.0.0",
         "symfony/filesystem": "^5.2.1 || ^6.0.0",


### PR DESCRIPTION
It's not used in Spryker packages directly and according to the ticket, TE-7125 was replaced with an ErrorHandler component.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
